### PR TITLE
Update README.md to account for renaming CEPs to RFCs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
-This repository contains the Coq Enhancement Proposals (CEP), the Coq equivalent of RFCs, PEPs and the like.
+This repository contains the RFCs (Requests for Comments) of the Rocq Prover
+(formerly, CEPs, for Coq Enhancement Proposals).
 
-To learn how CEPs work please read [CEP0](https://github.com/coq/ceps/blob/master/text/000-coq-enhancement-proposal.md)
+To learn how RFCs work please read [RFC #0](https://github.com/coq/ceps/blob/master/text/000-coq-enhancement-proposal.md).
+(Note that the text corresponds to the historical version when introducing CEPs,
+and was not modified to account for the renaming of Coq to the Rocq Prover.
+It may be subsumed by a new RFC process in the future.)


### PR DESCRIPTION
The new name was decided during the Coq Call of Nov 5th: https://github.com/coq/coq/wiki/Coq-Call-2024-11-05